### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,35 @@ A power menu built with GTK4. Works with wayland/xwayland, supports theming and 
 
 ## Installation
 
-Clone the project
-`git clone git@github.com:kamilernerd/pwrmenu.git`
+### 1. Install the application using `cargo`
 
-Simply run following in the project root
-`./install.sh`
+```bash
+cargo install --git https://github.com/kamilernerd/pwrmenu.git
+```
 
-If the script asks for password, provide it. The binary expects to have
+### 2. Set the Capabilities
+
+```bash
+sudo setcap cap_sys_boot+ep ${HOME}/.cargo/bin/pwrmenu
+```
+
+If the command asks for password, provide it. The binary expects to have
 CAP_SYS_BOOT capabilities.
 
 Read more here: https://man7.org/linux/man-pages/man7/capabilities.7.html
 
-The binary will be installed in $HOME/.cargo/bin/pwrmenu
+### 3. Now run `pwrmenu`
 
-Now run `pwrmenu`
+```bash
+pwrmenu [OPTION...]
+```
 
-When executed for the first time a `theme.css` and a `config.json` file will be created at `$HOME/.config/pwrmenu`.
+### *Notes*
 
-These files contain the theme which can be modified or turned off in the config file.
-
-You can also provide custom screen-lock command in the config file if you're using a different screen-locker.
+- The binary will be installed in `$HOME/.cargo/bin/pwrmenu`
+- When executed for the first time a `theme.css` and a `config.json` file will be created at `$HOME/.config/pwrmenu`.
+- These files contain the theme which can be modified or turned off in the config file.
+- You can optionaly also provide custom screen-lock command in the config file if you're using a different screen-locker.
 
 ## Preview
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-echo "Installing..."
-cargo install --path .
-echo "Installed in ${HOME}/.cargo/bin/pwrmenu"
-
-sudo setcap cap_sys_boot+ep ${HOME}/.cargo/bin/pwrmenu


### PR DESCRIPTION
# Simplification To Install

using the built in cargo install functionality `cargo install --git url...` standardizes the experience. I'm unsure of the purpose of the setcap command so I left it in the instructions this might somewhat negate the need of using a CI/CD pipelines Mentioned in #1 except from cargo.

Hope You Consider My Changes Thanks,
Liam